### PR TITLE
Fix bug with bills that have no payments

### DIFF
--- a/src/Components/bills/BillList.js
+++ b/src/Components/bills/BillList.js
@@ -35,13 +35,30 @@ export const BillList = (props) => {
                         {
                             bills.map(bill => {
                                 totalBudget += bill.expected_amount
-                                actualSpent += bill.payments[0].amount
-                              return  <tr key={bill.id}>
+                                
+                                
+                                return <tr key={bill.id}>
                                     <td>{bill.biller}</td>
                                     <td>${bill.expected_amount}</td>
                                     <td>{bill.due_date}</td>
-                                    <td>${bill.payments[0].amount}</td>
-                                    <td>{formatDate(bill.payments[0].date_paid)}</td>
+                                    {
+                                        bill.payments.length > 0
+                                         ? bill.payments.map(payment => {
+                                            if (payment.budget === parseInt(localStorage.getItem("budgetId"))) {
+                                                actualSpent += payment.amount
+                                                return <> <td>${bill.payments[0].amount}</td>
+                                                <td>{formatDate(bill.payments[0].date_paid)}</td> </>
+                                            
+                                            }
+                                            else {
+                                                return <Button color="success">Add payment</Button>
+                                            }
+                                        })
+                                        : <Button color="success">Add payment</Button>
+                                            
+                                            
+                                    }
+
                                 </tr>
                             })
                         }


### PR DESCRIPTION
# Description
added conditional logic that checks that the payments associated with a bill also correspond with the current budget. If they don't, or no corresponding payments exist at all, a button renders for adding payments. Currently the button has no functionality
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
