### PR TITLE
Fix bug on homepage when budget has no spending yet

### DIFF
--- a/src/Components/Homepage.js
+++ b/src/Components/Homepage.js
@@ -85,25 +85,25 @@ export const Homepage = (props) => {
                         <Card className="budget--item">
                             <CardTitle tag="h5">Total Budget</CardTitle>
                             <CardBody>
-                                <CardText>${currentBudget.total_budget.toFixed(2)}</CardText>
+                                <CardText>${currentBudget.total_budget}</CardText>
                             </CardBody>
                         </Card>
                         <Card className="budget--item">
                             <CardTitle tag="h5">Total spent</CardTitle>
                             <CardBody>
-                                <CardText>${currentBudget.total_spent.toFixed(2)}</CardText>
+                                <CardText>${currentBudget.total_spent}</CardText>
                             </CardBody>
                         </Card>
                         <Card className="budget--item">
                             <CardTitle tag="h5">Remaing budget</CardTitle>
                             <CardBody>
-                                <CardText>${currentBudget.remaining_budget.toFixed(2)}</CardText>
+                                <CardText>${currentBudget.remaining_budget}</CardText>
                             </CardBody>
                         </Card>
                         <Card className="budget--item">
                             <CardTitle tag="h5">Net total</CardTitle>
                             <CardBody>
-                                <CardText>${currentBudget.net_total.toFixed(2)}</CardText>
+                                <CardText>${currentBudget.net_total}</CardText>
                             </CardBody>
                         </Card>
                     </section>


### PR DESCRIPTION
# Description
Removed the toFixed methods on all the numbers. It was throwing an error when no data was present.
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
