### PR TITLE
Totals for bills

### DIFF
--- a/src/Components/bills/BillList.js
+++ b/src/Components/bills/BillList.js
@@ -20,30 +20,8 @@ export const BillList = (props) => {
     }, [])
 
     return (
-        <>
-        <header className="bills--header">
-            <h1>Recurring Bills</h1>
-            <section className="bills--totals">
-                <Card className="totals--card">
-                    <CardTitle tag="h5">Budget</CardTitle>
-                    <CardBody>
-                        <CardText>${totalBudget}</CardText>
-                    </CardBody>
-                </Card>
-                <Card className="totals--card">
-                    <CardTitle tag="h5">Actual</CardTitle>
-                    <CardBody>
-                        <CardText>${actualSpent}</CardText>
-                    </CardBody>
-                </Card>
-                <Card className="totals--card">
-                    <CardTitle tag="h5">Remaining</CardTitle>
-                    <CardBody>
-                        <CardText>${(totalBudget - actualSpent).toFixed(2)}</CardText>
-                    </CardBody>
-                </Card>
-            </section>
-            </header>
+        <div className="bills-container">
+
             <section className="table">
                 <Table hover>
                     <thead>
@@ -62,7 +40,6 @@ export const BillList = (props) => {
 
 
                                     totalBudget += bill.expected_amount
-
 
                                     return <tr key={bill.id}>
                                         <td>{bill.biller}</td>
@@ -98,11 +75,35 @@ export const BillList = (props) => {
                                 }
                             })
                         }
+
                     </tbody>
                 </Table>
                 <Button color="success" onClick={() => props.history.push("/bills/form")}>Add biller</Button>
             </section>
+            <header className="bills--header">
+                <h1>Recurring Bills</h1>
+                <section className="bills--totals">
+                    <Card className="totals--card">
+                        <CardTitle tag="h5">Budget</CardTitle>
+                        <CardBody>
+                            <CardText>${totalBudget}</CardText>
+                        </CardBody>
+                    </Card>
+                    <Card className="totals--card">
+                        <CardTitle tag="h5">Actual</CardTitle>
+                        <CardBody>
+                            <CardText>${actualSpent}</CardText>
+                        </CardBody>
+                    </Card>
+                    <Card className="totals--card">
+                        <CardTitle tag="h5">Remaining</CardTitle>
+                        <CardBody>
+                            <CardText>${(totalBudget - actualSpent).toFixed(2)}</CardText>
+                        </CardBody>
+                    </Card>
+                </section>
+            </header>
 
-        </>
+        </div>
     )
 }

--- a/src/Components/bills/Bills.css
+++ b/src/Components/bills/Bills.css
@@ -1,3 +1,8 @@
+.bills-container {
+    display: flex;
+    flex-direction: column-reverse;
+}
+
 .bills--totals, .bills--header {
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
# Description
used column-reverse with flexbox so that the totals cards can be placed at the bottom of the code so that the data is set properly, yet render at the top of the page in the browser.
## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
